### PR TITLE
fix: resolve unused write warnings in test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-03-23
+
+### Fixed
+- Fixed unused write warnings in test files (improved test coverage)
+- Added missing field assertions in TestItemIDField, TestItemJSONFields, and TestItemCopyCount
+
+---
+
 ## [Unreleased]
 
 ### Added
@@ -41,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Various bug fixes and improvements
+- Fixed unused write warnings in test files (improved test coverage)
 
 ---
 

--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -2,7 +2,7 @@
 Icon = "icon.png"
 Name = "FyClip"
 ID = "com.sarwar.fyclip"
-Version = "2.1.0"
+Version = "2.1.1"
 Build = 2
 
 [LinuxAndBSD]

--- a/build.sh
+++ b/build.sh
@@ -292,7 +292,7 @@ get_version() {
 # Main build function
 main() {
     echo -e "${BLUE}========================================${NC}"
-    echo -e "${BLUE}  FyClip Build Script v2.1${NC}"
+    echo -e "${BLUE}  FyClip Build Script v2.1.1${NC}"
     echo -e "${BLUE}  Auto-installs all dependencies${NC}"
     echo -e "${BLUE}========================================${NC}"
     echo ""

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "FyClip"
-#define MyAppVersion "2.1.0"
+#define MyAppVersion "2.1.1"
 #define MyAppPublisher "Sarwar Hossain"
 #define MyAppURL "https://github.com/Sarwarhridoy4/FyClip---Advanced-Clipboard-Manager/releases"
 #define MyAppExeName "FyClip---Advanced-Clipboard-Manager.exe"

--- a/internal/clipboard/item_test.go
+++ b/internal/clipboard/item_test.go
@@ -303,6 +303,26 @@ func TestItemIDField(t *testing.T) {
 		t.Errorf("ID = %v; want test-id-123", item.ID)
 	}
 
+	// Verify Type field is set correctly
+	if item.Type != TypeText {
+		t.Errorf("Type = %v; want TypeText", item.Type)
+	}
+
+	// Verify Content field is set correctly
+	if item.Content != "Test content" {
+		t.Errorf("Content = %v; want Test content", item.Content)
+	}
+
+	// Verify Timestamp is set
+	if item.Timestamp.IsZero() {
+		t.Error("Timestamp should not be zero")
+	}
+
+	// Verify Hash is set correctly
+	if item.Hash != "abc123" {
+		t.Errorf("Hash = %v; want abc123", item.Hash)
+	}
+
 	// Note: Pinned defaults to false (zero value)
 	// Test is primarily checking field assignment
 	_ = item.Pinned
@@ -333,11 +353,23 @@ func TestItemJSONFields(t *testing.T) {
 	if item.Type != TypeText {
 		t.Errorf("Type = %v; want TypeText", item.Type)
 	}
+	if item.Content != "test" {
+		t.Errorf("Content = %v; want test", item.Content)
+	}
+	if item.Timestamp.IsZero() {
+		t.Error("Timestamp should not be zero")
+	}
 	if !item.Pinned {
 		t.Error("Pinned should be true")
 	}
 	if item.CopyCount != 5 {
 		t.Errorf("CopyCount = %v; want 5", item.CopyCount)
+	}
+	if item.Hash != "hash123" {
+		t.Errorf("Hash = %v; want hash123", item.Hash)
+	}
+	if item.searchContent != "search" {
+		t.Errorf("searchContent = %v; want search", item.searchContent)
 	}
 }
 
@@ -360,6 +392,17 @@ func TestItemCopyCount(t *testing.T) {
 
 	if item.CopyCount != 2 {
 		t.Errorf("CopyCount = %v; want 2", item.CopyCount)
+	}
+
+	// Verify fields are set correctly
+	if item.ID != "copy-test" {
+		t.Errorf("ID = %v; want copy-test", item.ID)
+	}
+	if item.Type != TypeText {
+		t.Errorf("Type = %v; want TypeText", item.Type)
+	}
+	if item.Content != "Test" {
+		t.Errorf("Content = %v; want Test", item.Content)
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A modular, high-performance clipboard manager built with Go and Fyne v2.7+.
 
-**Current Version**: 2.1.0
+**Current Version**: 2.1.1
 
 ## Features
 
@@ -61,6 +61,7 @@ A modular, high-performance clipboard manager built with Go and Fyne v2.7+.
 - ✅ **Graceful Shutdown**: Context-based shutdown with hooks
 - ✅ **System Tray**: Recent items submenu, Clear History action
 - ✅ **Preview Enhancements**: JSON pretty-printing, file info display
+- ✅ **Test Coverage**: Improved test assertions to eliminate linter warnings
 
 ### Performance Snapshot (internal/clipboard benchmarks)
 


### PR DESCRIPTION
- Add field assertions in TestItemIDField, TestItemJSONFields, TestItemCopyCount
- Update version to 2.1.1 across all versioned files
- Update CHANGELOG.md with new version entry

Fixes unused write warnings detected by Go linter's unusedwrite analyzer.